### PR TITLE
Remove GemFury from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://gem.fury.io/fullscreen/'
 
 # Specify your gem's dependencies in yt.gemspec
 gemspec


### PR DESCRIPTION
It's not needed for any gem and makes 'bundle install' fail on
machines that do not have access to Gemfury.
